### PR TITLE
Fix page namespace imports

### DIFF
--- a/ChatPage.xaml.cs
+++ b/ChatPage.xaml.cs
@@ -1,6 +1,6 @@
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using LutecIA.ViewModels;
+using LutecIA;
 
 namespace LutecIA;
 public sealed partial class ChatPage : Page

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -19,7 +19,7 @@ public partial class MainWindow : Window
         SetTitleBar();
 
         // Navigate to default page
-        ContentFrame.Navigate(typeof(Views.ChatPage));
+        ContentFrame.Navigate(typeof(ChatPage));
     }
 
     void SetTitleBar()
@@ -37,7 +37,7 @@ public partial class MainWindow : Window
     {
         if (args.IsSettingsSelected)
         {
-            ContentFrame.Navigate(typeof(Views.SettingsPage));
+            ContentFrame.Navigate(typeof(SettingsPage));
             return;
         }
 
@@ -46,19 +46,19 @@ public partial class MainWindow : Window
             switch (tag)
             {
                 case "chat":
-                    ContentFrame.Navigate(typeof(Views.ChatPage));
+                    ContentFrame.Navigate(typeof(ChatPage));
                     break;
                 case "documents":
-                    ContentFrame.Navigate(typeof(Views.DocumentsPage));
+                    ContentFrame.Navigate(typeof(DocumentsPage));
                     break;
                 case "history":
-                    ContentFrame.Navigate(typeof(Views.HistoryPage));
+                    ContentFrame.Navigate(typeof(HistoryPage));
                     break;
                 case "users":
-                    ContentFrame.Navigate(typeof(Views.UsersPage));
+                    ContentFrame.Navigate(typeof(UsersPage));
                     break;
                 case "settings":
-                    ContentFrame.Navigate(typeof(Views.SettingsPage));
+                    ContentFrame.Navigate(typeof(SettingsPage));
                     break;
             }
         }


### PR DESCRIPTION
## Summary
- replace the invalid ViewModels namespace import in ChatPage with the correct root namespace
- update MainWindow navigation calls to reference the page types in their actual namespace

## Testing
- dotnet build *(fails in container: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d050a66de8832cb06d3a7fad875d65