### PR TITLE
Use built-in NavigationView settings item

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -9,7 +9,7 @@
     Title="LutecIA - Symplissime"
     Width="1200" Height="800">
     <Grid>
-        <NavigationView x:Name="NavView" PaneDisplayMode="Left" IsBackEnabled="False" SelectionChanged="NavView_SelectionChanged">
+        <NavigationView x:Name="NavView" PaneDisplayMode="Left" IsBackEnabled="False" IsSettingsVisible="True" SelectionChanged="NavView_SelectionChanged">
             <NavigationView.MenuItems>
                 <NavigationViewItem Content="Accueil" Tag="chat">
                     <NavigationViewItem.Icon>
@@ -32,14 +32,6 @@
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
             </NavigationView.MenuItems>
-            <NavigationView.SettingsItem>
-                <NavigationViewItem Content="Paramètres" Tag="settings">
-                    <NavigationViewItem.Icon>
-                        <SymbolIcon Symbol="Setting" />
-                    </NavigationViewItem.Icon>
-                </NavigationViewItem>
-            </NavigationView.SettingsItem>
-
             <Frame x:Name="ContentFrame"/>
         </NavigationView>
     </Grid>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -12,6 +12,13 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         this.InitializeComponent();
+
+        if (NavView.SettingsItem is NavigationViewItem settingsItem)
+        {
+            settingsItem.Content = "Paramètres";
+            settingsItem.Icon = new SymbolIcon(Symbol.Setting);
+        }
+
         this.DataContext = ViewModel;
 
         // Apply simple title bar integration for a modern look
@@ -56,9 +63,6 @@ public partial class MainWindow : Window
                     break;
                 case "users":
                     ContentFrame.Navigate(typeof(UsersPage));
-                    break;
-                case "settings":
-                    ContentFrame.Navigate(typeof(SettingsPage));
                     break;
             }
         }


### PR DESCRIPTION
## Summary
- rely on the NavigationView built-in settings button and enable it in the window XAML
- configure the settings item text and icon in the window constructor so it matches the previous custom entry
- simplify navigation logic now that the built-in IsSettingsSelected path handles settings navigation

## Testing
- `dotnet build` *(fails: command not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d05d9c2204832cb8a762380fc2f731

## Summary by Sourcery

Use the built-in NavigationView settings button instead of a custom entry, configure its label and icon in the window constructor, and remove the obsolete manual settings navigation logic

Enhancements:
- Enable and configure the built-in NavigationView settings item in XAML and set its localized label and icon in the MainWindow constructor
- Remove the custom settings navigation case from the selection handler and rely on NavigationView's built-in IsSettingsSelected path